### PR TITLE
Fixed saveImage and rotateImage crashes on Android

### DIFF
--- a/android/src/main/java/com/parsempo/ImageCropTools/ImageCropViewManager.kt
+++ b/android/src/main/java/com/parsempo/ImageCropTools/ImageCropViewManager.kt
@@ -74,12 +74,12 @@ class ImageCropViewManager: SimpleViewManager<CropImageView>() {
                     format = Bitmap.CompressFormat.PNG
                 }
                 val path = File(root.context.cacheDir, "${UUID.randomUUID()}.$extension").toURI().toString()
-                val quality = args?.getInt(0) ?: 100
+                val quality = args?.getInt(1) ?: 100
 
                 root.saveCroppedImageAsync(Uri.parse(path), format, quality)
             }
             ROTATE_IMAGE_COMMAND -> {
-                val clockwise = args?.getBoolean(1) ?: true
+                val clockwise = args?.getBoolean(0) ?: true
                 root.rotateImage(if (clockwise) 90 else -90)
             }
         }


### PR DESCRIPTION
Parameters for methods SAVE_IMAGE_COMMAND and ROTATE_IMAGE_COMMAND were expecting values on the wrong positions (Android)