### PR TITLE
do not zoom-in when rotating image on iOS

### DIFF
--- a/android/src/main/java/com/parsempo/ImageCropTools/ImageCropViewManager.kt
+++ b/android/src/main/java/com/parsempo/ImageCropTools/ImageCropViewManager.kt
@@ -32,7 +32,7 @@ class ImageCropViewManager: SimpleViewManager<CropImageView>() {
         view.setOnCropImageCompleteListener { _, result ->
             if (result.isSuccessful) {
                 val map = Arguments.createMap()
-                map.putString("uri", result.getUriFilePath(reactContext).toString())
+                map.putString("uri", result.getUriFilePath(reactContext, true).toString())
                 map.putInt("width", result.cropRect!!.width())
                 map.putInt("height", result.cropRect!!.height())
                 reactContext.getJSModule(RCTEventEmitter::class.java)?.receiveEvent(

--- a/ios/CropViewManager.m
+++ b/ios/CropViewManager.m
@@ -21,6 +21,8 @@ RCT_EXPORT_VIEW_PROPERTY(sourceUrl, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onImageSaved, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(keepAspectRatio, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(cropAspectRatio, CGSize)
+RCT_EXPORT_VIEW_PROPERTY(aspectRatioLockDimensionSwapEnabled, BOOL)
+
 
 RCT_EXPORT_METHOD(saveImage:(nonnull NSNumber*) reactTag
                   preserveTransparency:(BOOL) preserveTransparency
@@ -28,24 +30,24 @@ RCT_EXPORT_METHOD(saveImage:(nonnull NSNumber*) reactTag
     [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
         RCTCropView *cropView = (RCTCropView *)viewRegistry[reactTag];
         UIImage *image = [cropView getCroppedImage];
-        
+
         NSString *extension = @"jpg";
         if ([[image valueForKey:@"hasAlpha"] boolValue] && preserveTransparency) {
             extension = @"png";
         }
-        
+
         NSArray *paths = [[NSFileManager defaultManager] URLsForDirectory:NSCachesDirectory inDomains:NSUserDomainMask];
         NSURL *url = [[paths firstObject] URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], extension]];
-        
+
         if ([[image valueForKey:@"hasAlpha"] boolValue] && preserveTransparency) {
             [UIImagePNGRepresentation(image) writeToURL:url atomically:YES];
         }else {
             [UIImageJPEGRepresentation(image, [quality floatValue] / 100.0f) writeToURL:url atomically:YES];
         }
-        
+
         CGSize imageSize = image.size;
-        
-        
+
+
         cropView.onImageSaved(@{
             @"uri": url.absoluteString,
             @"width": [NSNumber numberWithDouble:imageSize.width],

--- a/ios/RCTCropView.h
+++ b/ios/RCTCropView.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSString * sourceUrl;
 @property (atomic, assign) BOOL keepAspectRatio;
+@property (atomic, assign) BOOL aspectRatioLockDimensionSwapEnabled;
 @property (nonatomic, assign) CGSize cropAspectRatio;
 @property (nonatomic, strong) RCTDirectEventBlock onImageSaved;
 

--- a/ios/RCTCropView.m
+++ b/ios/RCTCropView.m
@@ -43,7 +43,6 @@
         }
         _inlineCropView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _inlineCropView.frame = self.bounds;
-        _inlineCropView.backgroundColor = UIColor.blackColor;
         if (self->keepAspectRatio) {
             _inlineCropView.aspectRatioLockEnabled = keepAspectRatio;
         }
@@ -55,7 +54,6 @@
         }
         [_inlineCropView moveCroppedContentToCenterAnimated:NO];
         [_inlineCropView performInitialSetup];
-        self.backgroundColor =  UIColor.blackColor;
 
         [self addSubview:_inlineCropView];
     }

--- a/ios/RCTCropView.m
+++ b/ios/RCTCropView.m
@@ -15,7 +15,7 @@
     TOCropView * _inlineCropView;
 }
 
-@synthesize sourceUrl, keepAspectRatio, cropAspectRatio;
+@synthesize sourceUrl, keepAspectRatio, cropAspectRatio, aspectRatioLockDimensionSwapEnabled;
 
 - (void)layoutSubviews {
     if (_inlineCropView == nil) {
@@ -25,7 +25,7 @@
             requestOptions.resizeMode   = PHImageRequestOptionsResizeModeExact;
             requestOptions.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
             requestOptions.synchronous = YES;
-            
+
             PHAsset *photosAsset = [PHAsset fetchAssetsWithLocalIdentifiers:@[url] options: nil].lastObject;
             PHImageManager *manager = [PHImageManager defaultManager];
             __block UIImage *blockImage;
@@ -43,15 +43,20 @@
         }
         _inlineCropView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _inlineCropView.frame = self.bounds;
+        _inlineCropView.backgroundColor = UIColor.blackColor;
         if (self->keepAspectRatio) {
             _inlineCropView.aspectRatioLockEnabled = keepAspectRatio;
+        }
+        if (self->aspectRatioLockDimensionSwapEnabled) {
+            _inlineCropView.aspectRatioLockDimensionSwapEnabled = aspectRatioLockDimensionSwapEnabled;
         }
         if (!CGSizeEqualToSize(self -> cropAspectRatio, CGSizeZero)) {
             _inlineCropView.aspectRatio = self->cropAspectRatio;
         }
         [_inlineCropView moveCroppedContentToCenterAnimated:NO];
         [_inlineCropView performInitialSetup];
-        
+        self.backgroundColor =  UIColor.blackColor;
+
         [self addSubview:_inlineCropView];
     }
 }
@@ -80,6 +85,10 @@
 
 - (BOOL)keepAspectRatio {
     return _inlineCropView.aspectRatioLockEnabled;
+}
+
+- (BOOL)aspectRatioLockDimensionSwapEnabled {
+    return _inlineCropView.aspectRatioLockDimensionSwapEnabled;
 }
 
 - (void)rotateImage:(BOOL)clockwise {

--- a/src/crop-view.component.tsx
+++ b/src/crop-view.component.tsx
@@ -22,6 +22,7 @@ type Props = {
   onImageCrop?: (res: Response) => void;
   keepAspectRatio?: boolean;
   aspectRatio?: { width: number; height: number };
+  aspectRatioLockDimensionSwapEnabled?: boolean;
 };
 
 class CropView extends React.PureComponent<Props> {
@@ -48,7 +49,7 @@ class CropView extends React.PureComponent<Props> {
   };
 
   public render() {
-    const { sourceUrl, style, onImageCrop, keepAspectRatio, aspectRatio } = this.props;
+    const { sourceUrl, style, onImageCrop, keepAspectRatio, aspectRatio, aspectRatioLockDimensionSwapEnabled } = this.props;
 
     return (
       <RCTCropView
@@ -60,6 +61,7 @@ class CropView extends React.PureComponent<Props> {
         }}
         keepAspectRatio={keepAspectRatio}
         cropAspectRatio={aspectRatio}
+        aspectRatioLockDimensionSwapEnabled={aspectRatioLockDimensionSwapEnabled}
       />
     );
   }


### PR DESCRIPTION
When rotating image on iOS the image was zooming-in causing a bad UX. 

I've added a new boolean prop `aspectRatioLockDimensionSwapEnabled`, it's the name [TOCropViewController](https://github.com/TimOliver/TOCropViewController/blob/e0f1d29a4b79f7765b0f4c33a46b099f149c422b/CHANGELOG.md#added-7) is using, **we could make it shorter/better.**

related issue: https://github.com/hhunaid/react-native-image-crop-tools/issues/21

Before the patch:

https://user-images.githubusercontent.com/717975/142637772-d24864d6-3c5c-4e51-a745-4b5b208bd5ca.MP4

After the patch:


https://user-images.githubusercontent.com/717975/142639778-82664b34-925f-43cc-a6bf-1dbfda249215.MP4



