### PR TITLE
Switch dependency to React-Core

### DIFF
--- a/react-native-image-crop-tools.podspec
+++ b/react-native-image-crop-tools.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency 'TOCropViewController', '2.5.3'
 end
 


### PR DESCRIPTION
resolves #72

This resolves a problem with the package not pulling in all required dependencies in a project where use_frameworks is set. It will not change the behaviour of the package for anyone else - I've tested this with a fresh app to confirm.