### PR TITLE
Update react-native-image-crop-tools.podspec

### DIFF
--- a/react-native-image-crop-tools.podspec
+++ b/react-native-image-crop-tools.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency 'TOCropViewController', '2.5.3'
+  s.dependency 'TOCropViewController'
 end
 


### PR DESCRIPTION
No need to specify TOCropViewController version. This was preventing me from using other libraries like [react-native-image-crop-picker](https://github.com/ivpusic/react-native-image-crop-picker)

Fix bug #83